### PR TITLE
Make the field timezone aware

### DIFF
--- a/django_unixdatetimefield/fields.py
+++ b/django_unixdatetimefield/fields.py
@@ -1,4 +1,5 @@
 import datetime
+import pytz
 import time
 
 import django.db.models as models
@@ -31,7 +32,8 @@ class UnixDateTimeField(models.DateTimeField):
                 val = val.split(self.TZ_CONST)[0]
             return datetime.datetime.strptime(val, self.DEFAULT_DATETIME_FMT)
         else:
-            return datetime.datetime.fromtimestamp(float(val))
+            # Unix timestamp is always UTC by definition
+            return datetime.datetime.fromtimestamp(float(val), tz=pytz.timezone("UTC"))
 
     def _is_string(value, val):
         try:

--- a/django_unixdatetimefield/fields.py
+++ b/django_unixdatetimefield/fields.py
@@ -1,8 +1,9 @@
 import datetime
-import pytz
 import time
 
+from django.conf import settings
 import django.db.models as models
+from django.utils import timezone
 
 
 class UnixDateTimeField(models.DateTimeField):
@@ -33,7 +34,15 @@ class UnixDateTimeField(models.DateTimeField):
             return datetime.datetime.strptime(val, self.DEFAULT_DATETIME_FMT)
         else:
             # Unix timestamp is always UTC by definition
-            return datetime.datetime.fromtimestamp(float(val), tz=pytz.timezone("UTC"))
+            datetime_value = datetime.datetime.fromtimestamp(float(val))
+            if settings.USE_TZ:
+                try:
+                    import pytz
+                    return timezone.make_aware(datetime_value, timezone=pytz.timezone("UTC"))
+                except ImportError:
+                    return timezone.make_aware(datetime_value)
+            else: 
+                return datetime_value
 
     def _is_string(value, val):
         try:


### PR DESCRIPTION
Unix timestamp is UTC by definition.
This make it timezone aware and Django outputs correct time by default when using timezones.

I'm not sure about string parsing - what is the actual use case there, shouldn't the timestamp always be integer?